### PR TITLE
fix: presentations not opening correctly

### DIFF
--- a/src/jabberpoint/controller/KeyController.java
+++ b/src/jabberpoint/controller/KeyController.java
@@ -1,7 +1,6 @@
 package jabberpoint.controller;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyAdapter;
-import javax.swing.JFrame;
 import jabberpoint.command.Command;
 import jabberpoint.command.NextSlideCommand;
 import jabberpoint.command.PreviousSlideCommand;
@@ -17,7 +16,7 @@ import jabberpoint.model.PresentationReceiver;
  * @author Ian F. Darwin, ian@darwinsys.com, Gert Florijn, Sylvia Stuurman
  * @version 1.7 2024/04/01 Updated with improved documentation and encapsulation
  */
-public class KeyController extends KeyAdapter {
+public class KeyController extends KeyAdapter implements PresentationReceiver.PresentationUpdateListener {
     
     /**
      * Command for navigating to the next slide
@@ -35,16 +34,21 @@ public class KeyController extends KeyAdapter {
     private final Command exitCommand;
 
     /**
-     * Creates a new KeyController for the specified presentation.
+     * Creates a new KeyController with the specified presentation receiver.
      *
-     * @param presentation The presentation to control
-     * @param parentFrame The parent frame for dialogs
+     * @param receiver The presentation receiver to use for commands
      */
-    public KeyController(Presentation presentation, JFrame parentFrame) {
-        PresentationReceiver receiver = new PresentationReceiver(presentation, parentFrame);
+    public KeyController(PresentationReceiver receiver) {
+        receiver.addPresentationUpdateListener(this);  // Register for presentation updates
+        
         this.nextSlideCommand = new NextSlideCommand(receiver);
         this.prevSlideCommand = new PreviousSlideCommand(receiver);
         this.exitCommand = new ExitPresentationCommand(receiver);
+    }
+
+    @Override
+    public void onPresentationChanged(Presentation newPresentation) {
+        // No need to store the presentation reference as we use commands
     }
 
     /**
@@ -61,16 +65,15 @@ public class KeyController extends KeyAdapter {
             case KeyEvent.VK_PAGE_DOWN:
             case KeyEvent.VK_DOWN:
             case KeyEvent.VK_ENTER:
-            case '+':
+            case KeyEvent.VK_PLUS:
                 this.nextSlideCommand.execute();
                 break;
             case KeyEvent.VK_PAGE_UP:
             case KeyEvent.VK_UP:
-            case '-':
+            case KeyEvent.VK_MINUS:
                 this.prevSlideCommand.execute();
                 break;
-            case 'q':
-            case 'Q':
+            case KeyEvent.VK_Q:
                 this.exitCommand.execute();
                 break;
             default:

--- a/src/jabberpoint/controller/MenuController.java
+++ b/src/jabberpoint/controller/MenuController.java
@@ -13,6 +13,8 @@ import jabberpoint.command.NewPresentationCommand;
 import jabberpoint.command.OpenPresentationCommand;
 import jabberpoint.command.SavePresentationCommand;
 import jabberpoint.command.ExitPresentationCommand;
+import jabberpoint.command.NextSlideCommand;
+import jabberpoint.command.PreviousSlideCommand;
 import jabberpoint.ui.AboutBox;
 import jabberpoint.util.ErrorHandler;
 
@@ -24,7 +26,7 @@ import jabberpoint.util.ErrorHandler;
  * @author Ian F. Darwin, ian@darwinsys.com, Gert Florijn, Sylvia Stuurman
  * @version 1.7 2024/04/01 Updated with improved documentation and encapsulation
  */
-public class MenuController extends MenuBar {
+public class MenuController extends MenuBar implements PresentationReceiver.PresentationUpdateListener {
 	
 	private static final long serialVersionUID = 227L;
 	
@@ -36,7 +38,7 @@ public class MenuController extends MenuBar {
 	/**
 	 * The presentation being controlled.
 	 */
-	private final Presentation presentation;
+	private Presentation presentation;
 	
 	/**
 	 * Menu item labels
@@ -58,27 +60,38 @@ public class MenuController extends MenuBar {
 	private final Command openPresentationCommand;
 	private final Command savePresentationCommand;
 	private final Command exitPresentationCommand;
+	private final Command nextSlideCommand;
+	private final Command prevSlideCommand;
+	private final PresentationReceiver receiver;  // Store receiver reference for goto command
 
 	/**
-	 * Creates a new MenuController with the specified frame and presentation.
+	 * Creates a new MenuController with the specified frame and presentation receiver.
 	 *
 	 * @param frame The parent frame for dialogs
-	 * @param presentation The presentation to control
+	 * @param receiver The presentation receiver to use for commands
 	 */
-	public MenuController(Frame frame, Presentation presentation) {
+	public MenuController(Frame frame, PresentationReceiver receiver) {
 		this.parent = frame;
-		this.presentation = presentation;
+		this.presentation = receiver.getPresentation();
+		this.receiver = receiver;
+		receiver.addPresentationUpdateListener(this);  // Register for presentation updates
 		
-		PresentationReceiver receiver = new PresentationReceiver(presentation, (javax.swing.JFrame)frame);
 		this.newPresentationCommand = new NewPresentationCommand(receiver);
 		this.openPresentationCommand = new OpenPresentationCommand(receiver);
 		this.savePresentationCommand = new SavePresentationCommand(receiver);
 		this.exitPresentationCommand = new ExitPresentationCommand(receiver);
+		this.nextSlideCommand = new NextSlideCommand(receiver);
+		this.prevSlideCommand = new PreviousSlideCommand(receiver);
 		
 		// Create and configure menus
 		createFileMenu();
 		createViewMenu();
 		createHelpMenu();
+	}
+
+	@Override
+	public void onPresentationChanged(Presentation newPresentation) {
+		this.presentation = newPresentation;
 	}
 
 	/**
@@ -114,11 +127,11 @@ public class MenuController extends MenuBar {
 		Menu viewMenu = new Menu(VIEW);
 		
 		// Next slide menu item
-		MenuItem nextItem = createMenuItem(NEXT, '>', event -> presentation.nextSlide());
+		MenuItem nextItem = createMenuItem(NEXT, '>', event -> nextSlideCommand.execute());
 		viewMenu.add(nextItem);
 		
 		// Previous slide menu item
-		MenuItem prevItem = createMenuItem(PREV, '<', event -> presentation.prevSlide());
+		MenuItem prevItem = createMenuItem(PREV, '<', event -> prevSlideCommand.execute());
 		viewMenu.add(prevItem);
 		
 		// Go to slide menu item
@@ -126,7 +139,8 @@ public class MenuController extends MenuBar {
 			String pageNumberStr = JOptionPane.showInputDialog(parent, PAGENR);
 			try {
 				int pageNumber = Integer.parseInt(pageNumberStr);
-				presentation.setSlideNumber(pageNumber - 1);
+				// Use the receiver to access the current presentation
+				receiver.getPresentation().setSlideNumber(pageNumber - 1);
 			} catch (NumberFormatException ex) {
 				ErrorHandler.handleValidationError("Invalid page number format", parent);
 			}

--- a/src/jabberpoint/model/Presentation.java
+++ b/src/jabberpoint/model/Presentation.java
@@ -112,8 +112,10 @@ public class Presentation implements PresentationSubject {
 	 * Clears the presentation, removing all slides.
 	 */
 	public void clear() {
+		// Save current observers before clearing
+		ArrayList<PresentationObserver> currentObservers = this.observers;
 		this.showList = new ArrayList<>();
-		this.observers = new ArrayList<>();
+		this.observers = currentObservers;  // Restore observers
 		this.setSlideNumber(-1);
 	}
 
@@ -172,5 +174,14 @@ public class Presentation implements PresentationSubject {
 		for (PresentationObserver observer : this.observers) {
 			observer.onPresentationUpdate(this, this.getCurrentSlide());
 		}
+	}
+
+	/**
+	 * Gets the list of observers.
+	 *
+	 * @return The list of presentation observers
+	 */
+	public ArrayList<PresentationObserver> getObservers() {
+		return this.observers;
 	}
 }

--- a/src/jabberpoint/ui/SlideViewerFrame.java
+++ b/src/jabberpoint/ui/SlideViewerFrame.java
@@ -4,6 +4,7 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowAdapter;
 import javax.swing.JFrame;
 import jabberpoint.model.Presentation;
+import jabberpoint.model.PresentationReceiver;
 import jabberpoint.controller.KeyController;
 import jabberpoint.controller.MenuController;
 import jabberpoint.util.ErrorHandler;
@@ -65,10 +66,13 @@ public class SlideViewerFrame extends JFrame {
 			}
 		});
 		
+		// Create a single PresentationReceiver instance to be shared
+		PresentationReceiver receiver = new PresentationReceiver(presentation, this);
+		
 		// Add components and controllers
 		this.getContentPane().add(this.slideViewerComponent);
-		this.addKeyListener(new KeyController(presentation, this));
-		this.setMenuBar(new MenuController(this, presentation));
+		this.addKeyListener(new KeyController(receiver));
+		this.setMenuBar(new MenuController(this, receiver));
 		
 		// Set window properties
 		this.setSize(new Dimension(WIDTH, HEIGHT));


### PR DESCRIPTION
This pull request includes significant updates to the `KeyController`, `MenuController`, `Presentation`, `PresentationReceiver`, and `SlideViewerFrame` classes to improve encapsulation and enhance the handling of presentation updates. The key changes involve the introduction of a `PresentationReceiver` to manage presentation state and notify listeners of updates.

### Key Changes:

#### Encapsulation and Listener Updates:
* [`src/jabberpoint/controller/KeyController.java`](diffhunk://#diff-a01c43a3a42a46d3414ced1292109a131693408f3828746e98798d818b8a042bL20-R19): Modified `KeyController` to implement `PresentationReceiver.PresentationUpdateListener` and updated the constructor to use a `PresentationReceiver` instead of directly accessing the `Presentation`. [[1]](diffhunk://#diff-a01c43a3a42a46d3414ced1292109a131693408f3828746e98798d818b8a042bL20-R19) [[2]](diffhunk://#diff-a01c43a3a42a46d3414ced1292109a131693408f3828746e98798d818b8a042bL38-R53)
* [`src/jabberpoint/controller/MenuController.java`](diffhunk://#diff-d358de23b84654e22e3c6ed0ede2b31ed1bc0d6c77f1796556f5531b6845b801L27-R29): Updated `MenuController` to implement `PresentationReceiver.PresentationUpdateListener`, added new commands for slide navigation, and used `PresentationReceiver` for presentation state management. [[1]](diffhunk://#diff-d358de23b84654e22e3c6ed0ede2b31ed1bc0d6c77f1796556f5531b6845b801L27-R29) [[2]](diffhunk://#diff-d358de23b84654e22e3c6ed0ede2b31ed1bc0d6c77f1796556f5531b6845b801L39-R41) [[3]](diffhunk://#diff-d358de23b84654e22e3c6ed0ede2b31ed1bc0d6c77f1796556f5531b6845b801R63-R96)

#### Command Handling:
* [`src/jabberpoint/controller/KeyController.java`](diffhunk://#diff-a01c43a3a42a46d3414ced1292109a131693408f3828746e98798d818b8a042bL64-R76): Replaced character constants with `KeyEvent` constants for better readability and consistency in key event handling.
* [`src/jabberpoint/controller/MenuController.java`](diffhunk://#diff-d358de23b84654e22e3c6ed0ede2b31ed1bc0d6c77f1796556f5531b6845b801L117-R143): Updated menu item actions to use commands from `PresentationReceiver` instead of directly manipulating the `Presentation`.

#### Presentation State Management:
* [`src/jabberpoint/model/Presentation.java`](diffhunk://#diff-51df20340a9a8a02f2f7da0264e09ae3f7be6a898673dc4f7ce8476575baa4faR115-R118): Modified the `clear` method to preserve observers and added a method to retrieve the list of observers. [[1]](diffhunk://#diff-51df20340a9a8a02f2f7da0264e09ae3f7be6a898673dc4f7ce8476575baa4faR115-R118) [[2]](diffhunk://#diff-51df20340a9a8a02f2f7da0264e09ae3f7be6a898673dc4f7ce8476575baa4faR178-R186)
* [`src/jabberpoint/model/PresentationReceiver.java`](diffhunk://#diff-a3c37743ba2c1ca8d20ff844669ce771cbcf71c49fe86852378f91955380b782R24-R31): Introduced `PresentationUpdateListener` interface, methods to manage listeners, and updated methods to notify listeners of presentation changes. [[1]](diffhunk://#diff-a3c37743ba2c1ca8d20ff844669ce771cbcf71c49fe86852378f91955380b782R24-R31) [[2]](diffhunk://#diff-a3c37743ba2c1ca8d20ff844669ce771cbcf71c49fe86852378f91955380b782R41-R66) [[3]](diffhunk://#diff-a3c37743ba2c1ca8d20ff844669ce771cbcf71c49fe86852378f91955380b782L51-R105) [[4]](diffhunk://#diff-a3c37743ba2c1ca8d20ff844669ce771cbcf71c49fe86852378f91955380b782L71-R139)

#### Integration:
* [`src/jabberpoint/ui/SlideViewerFrame.java`](diffhunk://#diff-2611cd6abd995bcf137f2a574a159effd199aec0b1bbe90a20112f6f57313526R69-R75): Updated to create and use a single `PresentationReceiver` instance shared across different controllers.