### PR TITLE
fix: implement SOLID into XMLAccessor

### DIFF
--- a/src/jabberpoint/io/PresentationReader.java
+++ b/src/jabberpoint/io/PresentationReader.java
@@ -1,0 +1,11 @@
+package jabberpoint.io;
+
+import java.io.IOException;
+import jabberpoint.model.Presentation;
+
+/**
+ * Interface for reading presentations from a source.
+ */
+public interface PresentationReader {
+    void loadFile(Presentation presentation, String filename) throws IOException;
+} 

--- a/src/jabberpoint/io/PresentationWriter.java
+++ b/src/jabberpoint/io/PresentationWriter.java
@@ -1,0 +1,11 @@
+package jabberpoint.io;
+
+import java.io.IOException;
+import jabberpoint.model.Presentation;
+
+/**
+ * Interface for writing presentations to a destination.
+ */
+public interface PresentationWriter {
+    void saveFile(Presentation presentation, String filename) throws IOException;
+} 

--- a/src/jabberpoint/io/XMLAccessor.java
+++ b/src/jabberpoint/io/XMLAccessor.java
@@ -1,183 +1,40 @@
 package jabberpoint.io;
-import java.io.File;
+
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.FileWriter;
+import java.util.Arrays;
 import jabberpoint.model.Presentation;
-import jabberpoint.model.Slide;
-import jabberpoint.model.SlideItem;
-import jabberpoint.factory.SlideItemFactory;
-import jabberpoint.model.TextItem;
-import jabberpoint.model.BitmapItem;
-import jabberpoint.util.ErrorHandler;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.xml.sax.SAXException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.NodeList;
+import jabberpoint.io.xml.*;
 
 /**
  * XMLAccessor handles reading and writing presentations in XML format.
- * This class provides functionality to load presentations from XML files
- * and save presentations to XML files.
+ * This class acts as a facade for XML-based presentation storage operations.
  *
- * @author Ian F. Darwin, ian@darwinsys.com, Gert Florijn, Sylvia Stuurman
- * @version 1.0 2025/04/01
+ * @author Ian F. Darwin, ian@darwinsys.com, Gert Florijn, Sylvia Stuurman, Bram Suurd
+ * @version 2.0 2025/04/01
  */
 public class XMLAccessor extends Accessor {
-	
-    /**
-     * XML tag and attribute names
-     */
-    private static final String SHOW_TITLE = "showtitle";
-    private static final String SLIDE_TITLE = "title";
-    private static final String SLIDE = "slide";
-    private static final String ITEM = "item";
-    private static final String LEVEL = "level";
-    private static final String KIND = "kind";
-    private static final String TEXT = "text";
-    private static final String IMAGE = "image";
+    private final PresentationReader reader;
+    private final PresentationWriter writer;
     
-    /**
-     * XML document constants
-     */
-    private static final String XML_HEADER = "<?xml version=\"1.0\"?>";
-    private static final String DOCTYPE = "<!DOCTYPE presentation SYSTEM \"jabberpoint.dtd\">";
-    private static final String ROOT_ELEMENT = "presentation";
-    
-    /**
-     * Extracts the title from an XML element using the specified tag name.
-     *
-     * @param element The XML element to extract the title from
-     * @param tagName The name of the tag containing the title
-     * @return The title text content
-     */
-    private String getTitle(Element element, String tagName) {
-        NodeList titles = element.getElementsByTagName(tagName);
-        return titles.item(0).getTextContent();
+    public XMLAccessor() {
+        // Initialize serializers
+        var serializers = Arrays.asList(
+            new TextItemSerializer(),
+            new BitmapItemSerializer()
+        );
+        
+        // Initialize reader and writer
+        this.reader = new XMLReader(new DefaultXMLParser(), serializers);
+        this.writer = new XMLWriter(serializers);
     }
-
-    /**
-     * Loads a presentation from an XML file.
-     *
-     * @param presentation The presentation to load the data into
-     * @param filename The name of the file to load
-     * @throws IOException If there is an error reading the file
-     */
+    
     @Override
     public void loadFile(Presentation presentation, String filename) throws IOException {
-        try {
-            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();    
-            Document document = builder.parse(new File(filename));
-            Element root = document.getDocumentElement();
-            
-            // Set presentation title
-            presentation.setTitle(getTitle(root, SHOW_TITLE));
-
-            // Load all slides
-            NodeList slides = root.getElementsByTagName(SLIDE);
-            for (int i = 0; i < slides.getLength(); i++) {
-                Element xmlSlide = (Element) slides.item(i);
-                Slide slide = new Slide();
-                slide.setTitle(getTitle(xmlSlide, SLIDE_TITLE));
-                presentation.append(slide);
-                
-                // Load all items in the slide
-                NodeList slideItems = xmlSlide.getElementsByTagName(ITEM);
-                for (int j = 0; j < slideItems.getLength(); j++) {
-                    loadSlideItem(slide, (Element) slideItems.item(j));
-                }
-            }
-        } catch (ParserConfigurationException e) {
-            ErrorHandler.handleParserError(e, null);
-        } catch (SAXException e) {
-            ErrorHandler.handleParserError(e, null);
-        } catch (IOException e) {
-            throw e;
-        }
+        reader.loadFile(presentation, filename);
     }
-
-    /**
-     * Loads a single slide item from an XML element.
-     *
-     * @param slide The slide to add the item to
-     * @param item The XML element containing the item data
-     */
-    private void loadSlideItem(Slide slide, Element item) {
-        try {
-            // Get the level attribute
-            int level = 1; // default level
-            NamedNodeMap attributes = item.getAttributes();
-            String levelText = attributes.getNamedItem(LEVEL).getTextContent();
-            if (levelText != null) {
-                level = Integer.parseInt(levelText);
-            }
-
-            // Get the type and content
-            String type = attributes.getNamedItem(KIND).getTextContent();
-            String content = item.getTextContent();
-            
-            // Use the factory to create the appropriate slide item
-            SlideItem slideItem = SlideItemFactory.createSlideItem(type, level, content);
-            slide.append(slideItem);
-        } catch (NumberFormatException e) {
-            ErrorHandler.handleValidationError("Invalid level number in slide item", null);
-        } catch (IllegalArgumentException e) {
-            ErrorHandler.handleValidationError("Unknown slide item type", null);
-        }
-    }
-
-    /**
-     * Saves a presentation to an XML file.
-     *
-     * @param presentation The presentation to save
-     * @param filename The name of the file to save to
-     * @throws IOException If there is an error writing to the file
-     */
+    
     @Override
     public void saveFile(Presentation presentation, String filename) throws IOException {
-        try (PrintWriter out = new PrintWriter(new FileWriter(filename))) {
-            // Write XML header and presentation start
-            out.println(XML_HEADER);
-            out.println(DOCTYPE);
-            out.println("<" + ROOT_ELEMENT + ">");
-            
-            // Write presentation title
-            out.printf("<%s>%s</%s>%n", 
-                SHOW_TITLE, presentation.getTitle(), SHOW_TITLE);
-            
-            // Write each slide
-            for (int i = 0; i < presentation.getSize(); i++) {
-                Slide slide = presentation.getSlide(i);
-                out.println("<" + SLIDE + ">");
-                out.printf("<%s>%s</%s>%n", 
-                    SLIDE_TITLE, slide.getTitle(), SLIDE_TITLE);
-                
-                // Write slide items
-                for (SlideItem slideItem : slide.getSlideItems()) {
-                    out.print("<" + ITEM + " kind=\"");
-                    if (slideItem instanceof TextItem) {
-                        TextItem textItem = (TextItem) slideItem;
-                        out.printf("%s\" level=\"%d\">%s", 
-                            TEXT, slideItem.getLevel(), textItem.getText());
-                    } else if (slideItem instanceof BitmapItem) {
-                        BitmapItem bitmapItem = (BitmapItem) slideItem;
-                        out.printf("%s\" level=\"%d\">%s", 
-                            IMAGE, slideItem.getLevel(), bitmapItem.getImagePath());
-                    } else {
-                        ErrorHandler.handleValidationError("Unknown slide item type", null);
-                        continue;
-                    }
-                    out.println("</" + ITEM + ">");
-                }
-                out.println("</" + SLIDE + ">");
-            }
-            out.println("</" + ROOT_ELEMENT + ">");
-        }
+        writer.saveFile(presentation, filename);
     }
 }

--- a/src/jabberpoint/io/xml/BitmapItemSerializer.java
+++ b/src/jabberpoint/io/xml/BitmapItemSerializer.java
@@ -1,0 +1,38 @@
+package jabberpoint.io.xml;
+
+import org.w3c.dom.Element;
+import jabberpoint.model.SlideItem;
+import jabberpoint.model.BitmapItem;
+
+/**
+ * Serializer for BitmapItem slide items.
+ */
+public class BitmapItemSerializer implements SlideItemSerializer {
+    private static final String KIND = "image";
+    
+    @Override
+    public boolean supports(SlideItem item) {
+        return item instanceof BitmapItem;
+    }
+    
+    @Override
+    public String serialize(SlideItem item) {
+        if (!supports(item)) {
+            throw new IllegalArgumentException("Item must be a BitmapItem");
+        }
+        BitmapItem bitmapItem = (BitmapItem) item;
+        return String.format("kind=\"%s\" level=\"%d\">%s", 
+            KIND, item.getLevel(), bitmapItem.getImagePath());
+    }
+    
+    @Override
+    public SlideItem deserialize(Element element) throws XMLParserException {
+        try {
+            int level = Integer.parseInt(element.getAttribute("level"));
+            String imagePath = element.getTextContent();
+            return new BitmapItem(level, imagePath);
+        } catch (NumberFormatException e) {
+            throw new XMLParserException("Invalid level number for bitmap item", e);
+        }
+    }
+} 

--- a/src/jabberpoint/io/xml/DefaultXMLParser.java
+++ b/src/jabberpoint/io/xml/DefaultXMLParser.java
@@ -1,0 +1,21 @@
+package jabberpoint.io.xml;
+
+import java.io.File;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+
+/**
+ * Default implementation of XMLParser using DocumentBuilder.
+ */
+public class DefaultXMLParser implements XMLParser {
+    @Override
+    public Document parseXML(File file) throws XMLParserException {
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();    
+            return builder.parse(file);
+        } catch (Exception e) {
+            throw new XMLParserException("Error parsing XML file", e);
+        }
+    }
+} 

--- a/src/jabberpoint/io/xml/SlideItemSerializer.java
+++ b/src/jabberpoint/io/xml/SlideItemSerializer.java
@@ -1,0 +1,13 @@
+package jabberpoint.io.xml;
+
+import org.w3c.dom.Element;
+import jabberpoint.model.SlideItem;
+
+/**
+ * Interface for serializing and deserializing slide items to/from XML.
+ */
+public interface SlideItemSerializer {
+    String serialize(SlideItem item);
+    SlideItem deserialize(Element element) throws XMLParserException;
+    boolean supports(SlideItem item);
+} 

--- a/src/jabberpoint/io/xml/TextItemSerializer.java
+++ b/src/jabberpoint/io/xml/TextItemSerializer.java
@@ -1,0 +1,38 @@
+package jabberpoint.io.xml;
+
+import org.w3c.dom.Element;
+import jabberpoint.model.SlideItem;
+import jabberpoint.model.TextItem;
+
+/**
+ * Serializer for TextItem slide items.
+ */
+public class TextItemSerializer implements SlideItemSerializer {
+    private static final String KIND = "text";
+    
+    @Override
+    public boolean supports(SlideItem item) {
+        return item instanceof TextItem;
+    }
+    
+    @Override
+    public String serialize(SlideItem item) {
+        if (!supports(item)) {
+            throw new IllegalArgumentException("Item must be a TextItem");
+        }
+        TextItem textItem = (TextItem) item;
+        return String.format("kind=\"%s\" level=\"%d\">%s", 
+            KIND, item.getLevel(), textItem.getText());
+    }
+    
+    @Override
+    public SlideItem deserialize(Element element) throws XMLParserException {
+        try {
+            int level = Integer.parseInt(element.getAttribute("level"));
+            String text = element.getTextContent();
+            return new TextItem(level, text);
+        } catch (NumberFormatException e) {
+            throw new XMLParserException("Invalid level number for text item", e);
+        }
+    }
+} 

--- a/src/jabberpoint/io/xml/XMLParser.java
+++ b/src/jabberpoint/io/xml/XMLParser.java
@@ -1,0 +1,11 @@
+package jabberpoint.io.xml;
+
+import java.io.File;
+import org.w3c.dom.Document;
+
+/**
+ * Interface for XML parsing operations.
+ */
+public interface XMLParser {
+    Document parseXML(File file) throws XMLParserException;
+} 

--- a/src/jabberpoint/io/xml/XMLParserException.java
+++ b/src/jabberpoint/io/xml/XMLParserException.java
@@ -1,0 +1,14 @@
+package jabberpoint.io.xml;
+
+/**
+ * Custom exception for XML parsing errors.
+ */
+public class XMLParserException extends Exception {
+    public XMLParserException(String message) {
+        super(message);
+    }
+
+    public XMLParserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+} 

--- a/src/jabberpoint/io/xml/XMLReader.java
+++ b/src/jabberpoint/io/xml/XMLReader.java
@@ -1,0 +1,87 @@
+package jabberpoint.io.xml;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import jabberpoint.model.Presentation;
+import jabberpoint.model.Slide;
+import jabberpoint.model.SlideItem;
+import jabberpoint.io.PresentationReader;
+import jabberpoint.util.ErrorHandler;
+
+/**
+ * Implementation of PresentationReader for XML files.
+ */
+public class XMLReader implements PresentationReader {
+    private static final String SHOW_TITLE = "showtitle";
+    private static final String SLIDE = "slide";
+    private static final String SLIDE_TITLE = "title";
+    private static final String ITEM = "item";
+    
+    private final XMLParser parser;
+    private final List<SlideItemSerializer> serializers;
+    
+    public XMLReader(XMLParser parser, List<SlideItemSerializer> serializers) {
+        this.parser = parser;
+        this.serializers = serializers;
+    }
+    
+    @Override
+    public void loadFile(Presentation presentation, String filename) throws IOException {
+        try {
+            Document document = parser.parseXML(new File(filename));
+            Element root = document.getDocumentElement();
+            
+            // Set presentation title
+            presentation.setTitle(getTitle(root, SHOW_TITLE));
+            
+            // Load slides
+            NodeList slides = root.getElementsByTagName(SLIDE);
+            for (int i = 0; i < slides.getLength(); i++) {
+                loadSlide(presentation, (Element) slides.item(i));
+            }
+        } catch (XMLParserException e) {
+            ErrorHandler.handleParserError(e, null);
+            throw new IOException("Failed to parse XML file", e);
+        }
+    }
+    
+    private String getTitle(Element element, String tagName) {
+        NodeList titles = element.getElementsByTagName(tagName);
+        return titles.item(0).getTextContent();
+    }
+    
+    private void loadSlide(Presentation presentation, Element slideElement) throws XMLParserException {
+        Slide slide = new Slide();
+        slide.setTitle(getTitle(slideElement, SLIDE_TITLE));
+        presentation.append(slide);
+        
+        NodeList items = slideElement.getElementsByTagName(ITEM);
+        for (int i = 0; i < items.getLength(); i++) {
+            Element itemElement = (Element) items.item(i);
+            String kind = itemElement.getAttribute("kind");
+            
+            SlideItem item = deserializeItem(itemElement, kind);
+            if (item != null) {
+                slide.append(item);
+            }
+        }
+    }
+    
+    private SlideItem deserializeItem(Element element, String kind) throws XMLParserException {
+        for (SlideItemSerializer serializer : serializers) {
+            try {
+                SlideItem item = serializer.deserialize(element);
+                if (item != null) {
+                    return item;
+                }
+            } catch (XMLParserException e) {
+                // Continue trying other serializers
+            }
+        }
+        throw new XMLParserException("No suitable serializer found for item kind: " + kind);
+    }
+} 

--- a/src/jabberpoint/io/xml/XMLWriter.java
+++ b/src/jabberpoint/io/xml/XMLWriter.java
@@ -1,0 +1,81 @@
+package jabberpoint.io.xml;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import jabberpoint.model.Presentation;
+import jabberpoint.model.Slide;
+import jabberpoint.model.SlideItem;
+import jabberpoint.io.PresentationWriter;
+import jabberpoint.util.ErrorHandler;
+
+/**
+ * Implementation of PresentationWriter for XML files.
+ */
+public class XMLWriter implements PresentationWriter {
+    private static final String XML_HEADER = "<?xml version=\"1.0\"?>";
+    private static final String DOCTYPE = "<!DOCTYPE presentation SYSTEM \"jabberpoint.dtd\">";
+    private static final String ROOT_ELEMENT = "presentation";
+    private static final String SHOW_TITLE = "showtitle";
+    private static final String SLIDE = "slide";
+    private static final String SLIDE_TITLE = "title";
+    private static final String ITEM = "item";
+    
+    private final List<SlideItemSerializer> serializers;
+    
+    public XMLWriter(List<SlideItemSerializer> serializers) {
+        this.serializers = serializers;
+    }
+    
+    @Override
+    public void saveFile(Presentation presentation, String filename) throws IOException {
+        try (PrintWriter out = new PrintWriter(new FileWriter(filename))) {
+            writeHeader(out);
+            writePresentation(out, presentation);
+        }
+    }
+    
+    private void writeHeader(PrintWriter out) {
+        out.println(XML_HEADER);
+        out.println(DOCTYPE);
+        out.println("<" + ROOT_ELEMENT + ">");
+    }
+    
+    private void writePresentation(PrintWriter out, Presentation presentation) {
+        writePresentationTitle(out, presentation.getTitle());
+        
+        for (int i = 0; i < presentation.getSize(); i++) {
+            writeSlide(out, presentation.getSlide(i));
+        }
+        
+        out.println("</" + ROOT_ELEMENT + ">");
+    }
+    
+    private void writePresentationTitle(PrintWriter out, String title) {
+        out.printf("<%s>%s</%s>%n", SHOW_TITLE, title, SHOW_TITLE);
+    }
+    
+    private void writeSlide(PrintWriter out, Slide slide) {
+        out.println("<" + SLIDE + ">");
+        out.printf("<%s>%s</%s>%n", SLIDE_TITLE, slide.getTitle(), SLIDE_TITLE);
+        
+        for (SlideItem item : slide.getSlideItems()) {
+            writeSlideItem(out, item);
+        }
+        
+        out.println("</" + SLIDE + ">");
+    }
+    
+    private void writeSlideItem(PrintWriter out, SlideItem item) {
+        for (SlideItemSerializer serializer : serializers) {
+            if (serializer.supports(item)) {
+                out.print("<" + ITEM + " ");
+                out.print(serializer.serialize(item));
+                out.println("</" + ITEM + ">");
+                return;
+            }
+        }
+        ErrorHandler.handleValidationError("No suitable serializer found for item", null);
+    }
+} 


### PR DESCRIPTION
This pull request introduces a major refactor of the XML handling for presentations in the `jabberpoint` application. The changes include the introduction of new interfaces and classes to modularize and simplify the reading and writing of presentations to and from XML files. The most important changes are summarized below:

### Introduction of Interfaces for Reading and Writing Presentations
* Added `PresentationReader` and `PresentationWriter` interfaces to define the contract for reading and writing presentations. (`src/jabberpoint/io/PresentationReader.java` - [[1]](diffhunk://#diff-0cc72cf111f9761bc88fba73775b22e123fa8dde6c19fee4ab0008c46ea7c0afR1-R11) `src/jabberpoint/io/PresentationWriter.java` - [[2]](diffhunk://#diff-1f24d08bba653a6e87acaa9b55914a481f0ed73eaafcc497cf7fc36b1f392df7R1-R11)

### Refactor of XML Accessor
* Refactored `XMLAccessor` to use the new `PresentationReader` and `PresentationWriter` interfaces, delegating XML parsing and serialization to specialized classes. (`src/jabberpoint/io/XMLAccessor.java` - [src/jabberpoint/io/XMLAccessor.javaL2-R38](diffhunk://#diff-e16c31003b0a0dc94d5e87450a493f3ee891252fa5c0de0a3937b47d5a66399cL2-R38))

### Modular XML Parsing and Serialization
* Introduced `DefaultXMLParser` as the default implementation of the new `XMLParser` interface for parsing XML files. (`src/jabberpoint/io/xml/DefaultXMLParser.java` - [[1]](diffhunk://#diff-d5c1a51fbee5d3d044979c8325a465b650a7c2bc2092e2557640b3ff5e3ca75bR1-R21) `src/jabberpoint/io/xml/XMLParser.java` - [[2]](diffhunk://#diff-4caedddb6d44a3145b707ecf9684d31460d1c647e52b84f8f7feff03bc0a1ae7R1-R11)
* Created `XMLReader` and `XMLWriter` classes to handle reading from and writing to XML files using the new modular serializers. (`src/jabberpoint/io/xml/XMLReader.java` - [[1]](diffhunk://#diff-4ed31f2dcc9ac5239dc2d137898fcad4542ebdde4a4d604394545ee422580400R1-R87) `src/jabberpoint/io/xml/XMLWriter.java` - [[2]](diffhunk://#diff-700cc32d86a30716fa99fdc873987cc964e807cdda4cb78e990dfb6019d82182R1-R81)

### Slide Item Serialization
* Added `SlideItemSerializer` interface and specific implementations (`TextItemSerializer` and `BitmapItemSerializer`) for serializing and deserializing different types of slide items. (`src/jabberpoint/io/xml/SlideItemSerializer.java` - [[1]](diffhunk://#diff-0300d85ca6f1415e56cb1dcbc213e1d0b3774bbbcb7bce1dd67e8043692ae95eR1-R13) `src/jabberpoint/io/xml/TextItemSerializer.java` - [[2]](diffhunk://#diff-060ce72e92d4f889f2dcc409b31fbf7a2ad258c8a7dcd0f4bf0bfbb1ea15858aR1-R38) `src/jabberpoint/io/xml/BitmapItemSerializer.java` - [[3]](diffhunk://#diff-7970c540bac7246610b28e661d83370e7e735e8e2522ae6a187cd400611e6dc7R1-R38)

### Error Handling
* Introduced `XMLParserException` to handle XML parsing errors in a more structured way. (`src/jabberpoint/io/xml/XMLParserException.java` - [src/jabberpoint/io/xml/XMLParserException.javaR1-R14](diffhunk://#diff-ab6ffd8875b7011f691a05993f211a768275830b17eda95d987a2fac7a5a3d51R1-R14))